### PR TITLE
don't mask websocket frames from server

### DIFF
--- a/pico_http/websocket_handler.cpp
+++ b/pico_http/websocket_handler.cpp
@@ -145,8 +145,7 @@ bool WebSocketHandler::encodeData(const uint8_t* data, size_t len, WebSocketInte
 
     // FIN + operation
     buffer[0] = 0x80 | WebSocketOperation::BINARY_FRAME;
-    buffer[1] |= 0x80;
-    
+
     if (len < 126)
     {
         buffer[1] |= len;
@@ -173,15 +172,11 @@ bool WebSocketHandler::encodeData(const uint8_t* data, size_t len, WebSocketInte
         headerSize += 10;
     }
 
-    // Empty mask for now
-    headerSize+=4;
-    
-    // 4 mask bytes if needed
     if (!callback->onWebsocketEncodedData(&buffer[0], headerSize))
     {
         return false;
     }
-    
+
     return callback->onWebsocketEncodedData(data, len);
 }
 


### PR DESCRIPTION
Hey thanks a lot for your great library!

I had issue with Chrome clients, which closed the websocket after receiving the first message from the server.
The reason was kindly given by the Chrome console: 
`A server must not mask any frames that it sends to the client.`

This PR just removes the mask bit from the 2nd bytes, and the additional 4 ending bytes.